### PR TITLE
Bugfix for making Graudit work on Macs

### DIFF
--- a/graudit
+++ b/graudit
@@ -24,7 +24,7 @@ if [ ! -x $BINFILE ]; then
     echo "grep not found!"
     exit 2
 fi
-/bin/grep --exclude-dir=. test "$0" >/dev/null 2>&1
+$BINFILE --exclude-dir=. test "$0" >/dev/null 2>&1
 if [ $? -eq 2 ]; then
     echo $?
     echo "Graudit requires a newer version of grep (>=2.5.3)"


### PR DESCRIPTION
Currently, the code hardcodes the path /bin/grep in an early test of grep, but correctly uses $BINFILE elsewhere in the code. Under Mac, this is /usr/bin/grep, so on Macs graudit dies silent. This one line fix should address the issue.
