### PR TITLE
look for common C bugs

### DIFF
--- a/signatures/all.db
+++ b/signatures/all.db
@@ -334,14 +334,14 @@ strncat
 getwd
 umask
 AddAccessAllowedAce
-# sw bugs from aaron campbell
-flags\ *&&\ *[A-Z_]+
-\[sizeof\(.*\)\]\ *=\ *'?\\?0'?;$
-^[\ \t]*printf\(getenv
+# sw bugs from aaron campbell, see https://www.arbornetworks.com/blog/asert/static-code-analysis-using-google-code-search/
+flags\s*&&\s*[A-Z_]+
+\[sizeof\(.*\)\]\s*=\s*'?\\?0'?;$
+^[\s\t]*printf\(getenv
 if \(errno = E
 <= 65553
 0xfffffff[^0-9a-f]
-getopt\ *\(argc,\ *argv,\ *\"[^\"]*;# Dotnet cookies
+getopt\s*\(argc,\s*argv,\s*\"[^\"]*;# Dotnet cookies
 # Cookie manipulation can be key to various application security exploits, such as session hijacking/fixation and parameter
 # manipulation.
 System.Net.Cookie

--- a/signatures/all.db
+++ b/signatures/all.db
@@ -334,7 +334,14 @@ strncat
 getwd
 umask
 AddAccessAllowedAce
-# Dotnet cookies
+# sw bugs from aaron campbell
+flags\ *&&\ *[A-Z_]+
+\[sizeof\(.*\)\]\ *=\ *'?\\?0'?;$
+^[\ \t]*printf\(getenv
+if \(errno = E
+<= 65553
+0xfffffff[^0-9a-f]
+getopt\ *\(argc,\ *argv,\ *\"[^\"]*;# Dotnet cookies
 # Cookie manipulation can be key to various application security exploits, such as session hijacking/fixation and parameter
 # manipulation.
 System.Net.Cookie

--- a/signatures/c.db
+++ b/signatures/c.db
@@ -281,3 +281,11 @@ strncat
 getwd
 umask
 AddAccessAllowedAce
+# sw bugs from aaron campbell, see https://www.arbornetworks.com/blog/asert/static-code-analysis-using-google-code-search/
+flags\ *&&\ *[A-Z_]+
+\[sizeof\(.*\)\]\ *=\ *'?\\?0'?;$
+^[\ \t]*printf\(getenv
+if \(errno = E
+<= 65553
+0xfffffff[^0-9a-f]
+getopt\ *\(argc,\ *argv,\ *\"[^\"]*;

--- a/signatures/c.db
+++ b/signatures/c.db
@@ -282,10 +282,10 @@ getwd
 umask
 AddAccessAllowedAce
 # sw bugs from aaron campbell, see https://www.arbornetworks.com/blog/asert/static-code-analysis-using-google-code-search/
-flags\ *&&\ *[A-Z_]+
-\[sizeof\(.*\)\]\ *=\ *'?\\?0'?;$
-^[\ \t]*printf\(getenv
+flags\s*&&\s*[A-Z_]+
+\[sizeof\(.*\)\]\s*=\s*'?\\?0'?;$
+^[\s\t]*printf\(getenv
 if \(errno = E
 <= 65553
 0xfffffff[^0-9a-f]
-getopt\ *\(argc,\ *argv,\ *\"[^\"]*;
+getopt\s*\(argc,\s*argv,\s*\"[^\"]*;


### PR DESCRIPTION
- off by one
- format strings
- typos

these are sometimes security related flaws, see https://www.arbornetworks.com/blog/asert/static-code-analysis-using-google-code-search/