### PR TITLE
Add COBOL signatures

### DIFF
--- a/signatures/cobol.db
+++ b/signatures/cobol.db
@@ -1,0 +1,12 @@
+# file IO
+open[[:space:]]input[[:space:]]
+open[[:space:]]output[[:space:]]
+read[[:space:]]
+write[[:space:]]
+delete[[:space:]]
+# subroutines
+call[[:space:]]
+# debugging
+with[[:space:]]debugging[[:space:]]mode
+# dangerous
+accept[[:space:]]


### PR DESCRIPTION
Adds rudimentary signatures for COBOL.

Consider the following deliberately vulnerable GnuCOBOL program.

```cobol
       >>SOURCE FORMAT FREE
       identification division.
       program-id. hello.

       environment division.
       configuration section.
       repository. function all intrinsic.

       input-output section.
       file-control.
           select sysin assign to KEYBOARD organization line sequential.

       data division.
       file section.
           fd sysin.
           01 sysin-buffer pic X(255).
           88 EOF value high-values.

       procedure division.
           display "Hello. What is your name?"
           open input sysin
           read sysin
               at end set EOF to true
           end-read

           CALL "SYSTEM" USING CONCATENATE("echo Hello ", sysin-buffer, "\!")

           close sysin.

           stop run.
```

Prior to this PR, the `perl/perl.original` signatures were the only graudit signatures to return results for COBOL programs. Low hanging fruit, such as calls to unsafe external subroutines (such as `system`) were missed, as all other signatures expected the string `system` to be followed by `(`, which is invalid for COBOL syntax.

```
user@linux-mint-19-2:~/cobol/graudit$ ./graudit -B -i -d /home/user/cobol/graudit/signatures/default.db /tmp/hello.cbl 
user@linux-mint-19-2:~/cobol/graudit$ ./graudit -B -i -d /home/user/cobol/graudit/signatures/c.db /tmp/hello.cbl 
user@linux-mint-19-2:~/cobol/graudit$ ./graudit -B -i -d /home/user/cobol/graudit/signatures/exec.db /tmp/hello.cbl 
user@linux-mint-19-2:~/cobol/graudit$ ./graudit -B -i -d /home/user/cobol/graudit/signatures/perl/perl.original /tmp/hello.cbl 
/tmp/hello.cbl-20-           display "Hello. What is your name?"
/tmp/hello.cbl:21:           open input sysin
/tmp/hello.cbl:22:           read sysin
/tmp/hello.cbl-23-               at end set EOF to true
/tmp/hello.cbl:24:           end-read
/tmp/hello.cbl-25-
/tmp/hello.cbl:26:           CALL "SYSTEM" USING CONCATENATE("echo Hello ", sysin-buffer, "\!")
/tmp/hello.cbl-27-
```

Note that the `cobol.db` signatures added in this PR yield similar results to the `perl/perl.original` signatures :

```
user@linux-mint-19-2:~/cobol/graudit$ ./graudit -B -i -d /home/user/cobol/graudit/signatures/cobol.db /tmp/hello.cbl 
/tmp/hello.cbl-20-           display "Hello. What is your name?"
/tmp/hello.cbl:21:           open input sysin
/tmp/hello.cbl:22:           read sysin
/tmp/hello.cbl-23-               at end set EOF to true
##############################################
/tmp/hello.cbl-25-
/tmp/hello.cbl:26:           CALL "SYSTEM" USING CONCATENATE("echo Hello ", sysin-buffer, "\!")
/tmp/hello.cbl-27-
user@linux-mint-19-2:~/cobol/graudit$ 
```

---

### Notes

COBOL code can be case insensitive. Using `graudit` with the `-i` flag for case-insensitive searching is recommended.

Eliminating false positives is problematic due to syntax and whitespace formatting rules.

For example, the following code uses `open` to open two files: one in `input` mode, and one in `output` mode:

```
           open input input-file
               output output-file
```

Similarly, new lines can be used liberally. The following code is identical in operation.

```cobol
CALL "SYSTEM" using '/bin/sh -c "id"'
```

```cobol
CALL "SYSTEM"
  using '/bin/sh -c "id"'
```

For these reasons, I opted to use simple signatures. In the `open` example, the following signatures will at least match the first line, causing the second line to also be included in the surrounding lines output.

```
open[[:space:]]input[[:space:]]
open[[:space:]]output[[:space:]]
```

In the `CALL` example, the following signature will simply match every `CALL` to a subroutine as a potential item of interest.

```
call[[:space:]]
```

Further refining of signatures for low hanging fruit is problematic. The majority of complex and useful functionality utilised by COBOL programs is thanks to easy execution of subroutines through [CALL](https://www.tutorialspoint.com/cobol/cobol_subroutines.htm).

This procedure effectively allows dynamic code execution, as the subroutine name is a string which can be defined elsewhere in the program or from user input. For this reason, every `CALL` is potentially of interest.
