### PR TITLE
Skip devices

### DIFF
--- a/graudit
+++ b/graudit
@@ -185,6 +185,7 @@ fi
 # -n prints the line number
 banner
 $BINFILE --color=$color \
+         --devices=skip \
          --exclude-dir=.svn \
          --exclude-dir=CVS \
          --exclude-dir=.git \


### PR DESCRIPTION
This PR updates the `grep` command to skip devices using the `--devices` flag, which prevents graudit from getting stuck trying to read named pipes (or devices).

While it's unlikely that named pipes will be encountered, the expected behavior is *probably* that these will be skipped.

The `--devices` flag is available in GNU Grep, but not available in BSD's Grep.

This should not be a problem, as `graudit` requires GNU Grep >= 2.5.3 due to the use of the `--exclude-dir=` flag. I'm not sure when the `--devices` flag was added; however, I checked an old Ubuntu 10.04 system which had GNU grep 2.5.4, and this version supported the `--devices` flag.

For reference, [this StackOverflow post](https://unix.stackexchange.com/a/499231) outlines the behavior of `grep` in relation to named pipes.
