### PR TITLE
Regex typo in python

### DIFF
--- a/signatures/python.db
+++ b/signatures/python.db
@@ -14,7 +14,7 @@ rmdir
 remove[[:space:]]*\(
 \.unlink[[:space:]]*\(
 link[[:space:]]*\(
-execv[[:space:]]\(
+execv[[:space:]]*\(
 execve[[:space:]]*\(
 execl[[:space:]]*\(
 execlp[[:space:]]*\(

--- a/signatures/python/original.db
+++ b/signatures/python/original.db
@@ -14,7 +14,7 @@ rmdir
 remove[[:space:]]*\(
 \.unlink[[:space:]]*\(
 link[[:space:]]*\(
-execv[[:space:]]\(
+execv[[:space:]]*\(
 execve[[:space:]]*\(
 execl[[:space:]]*\(
 execlp[[:space:]]*\(


### PR DESCRIPTION
Change `execv[[:space:]]\(` to `execv[[:space:]]*\(`