### PR TITLE
Removed bash wildcard from GRDIR env var string

### DIFF
--- a/graudit
+++ b/graudit
@@ -82,7 +82,7 @@ listdb () {
     set +o pipefail
     banner
     if [ -n "$GRDIR" ] && [ -d "$GRDIR" ]; then
-        ls -1 "$GRDIR/*.db" 2>/dev/null
+        ls -1 "$GRDIR"/*.db 2>/dev/null
     fi
     if [ -d /usr/share/graudit/ ]; then
         ls -1 /usr/share/graudit/*.db 2>/dev/null


### PR DESCRIPTION
`$GRDIR` is correctly stringified to handle spaces and special characters. However, the wildcard character was included, thus `ls` never returned results. 