### PR TITLE
$basedir follows symbolic link

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,6 @@
+3.1		2021 Jun 02
+		Updated $basedir to follow symbolic links
+
 3.0		2021 Apr 29
 		Fixed broken Java rule causing massive false positives
 		Additional PHP fruit rules

--- a/graudit
+++ b/graudit
@@ -4,7 +4,7 @@
 # Released under the GPL licence
 set -e
 set -o pipefail
-VERSION='3.0'
+VERSION='3.1'
 SCRIPT_PATH=$(readlink -f "$0")
 basedir=$(dirname "$SCRIPT_PATH")
 BINFILE=$(which grep)
@@ -44,7 +44,7 @@ banner() {
         \___  /|__|  (____  /____/\____ | |__||__|  
        /_____/            \/           \/           
               grep rough audit - static analysis tool
-                  v3.0 written by @Wireghoul
+                  v3.1 written by @Wireghoul
 =================================[justanotherhacker.com]==='
     fi
 }

--- a/graudit
+++ b/graudit
@@ -5,7 +5,8 @@
 set -e
 set -o pipefail
 VERSION='3.0'
-basedir=$(dirname "$0")
+SCRIPT_PATH=$(readlink -f "$0")
+basedir=$(dirname "$SCRIPT_PATH")
 BINFILE=$(which grep)
 
 # Default values

--- a/graudit.in.1
+++ b/graudit.in.1
@@ -1,6 +1,6 @@
 .\"	$Id: template.in.1,v 1.1 2010/06/02 12:15:32 kristaps Exp $
 .\"
-.\" (C) Copyletft Eldar "Wireghoul" Marcussen - http://www.justanotherhacker.com.
+.\" (C) Copyleft Eldar "Wireghoul" Marcussen - http://www.justanotherhacker.com.
 .\"
 .\" See mdoc(7) for further reference.
 .\"

--- a/graudit.in.7
+++ b/graudit.in.7
@@ -1,5 +1,5 @@
 .\"
-.\" (C) Copyletft Eldar "Wireghoul" Marcussen - http://www.justanotherhacker.com.
+.\" (C) Copyleft Eldar "Wireghoul" Marcussen - http://www.justanotherhacker.com.
 .\"
 .\" See mdoc(7) for further reference.
 .\"


### PR DESCRIPTION
README instructs users to clone the repository to ~/graudit and create a symbolic link to the shell script, however $(dirname "{0}") will not follow the symbolic link, causing various program flows to fail that require relative imports, such as listing the available databases.