### PR TITLE
Added Template literals (Template strings) detection

### DIFF
--- a/signatures/js.db
+++ b/signatures/js.db
@@ -1,3 +1,5 @@
+`
+` .*(\$) `
 (document|\$)\.cookie[[:space:]]*\(
 nodeIntegration
 nodeIntegrationInWorker

--- a/signatures/js.db
+++ b/signatures/js.db
@@ -1,5 +1,5 @@
-`
-` .*(\$) `
+.*=[[:space:]]*`
+`.*\$\{.*`
 (document|\$)\.cookie[[:space:]]*\(
 nodeIntegration
 nodeIntegrationInWorker


### PR DESCRIPTION
Imagine a bit of JavaScript (JS) code like here:

```javascript
let html = `
  <div class="image-box">
    <img class="image"
         src="${imageUrl}"/>
  </div>`;
// (...)
main.innerHTML = html;
```


You first will notice the variable called html, which constructs a bit of HTML using a Javascript template string. It also features an inclusion of another variable – imageUrl – to be used in the src attribute. The full html string is then assigned to main.innerHTML.

If we assume that the imageUrl variable is controlled by an attacker – then they might easily break out of the src attribute syntax and enter arbitrary HTML of their choosing to launch an XSS attack.

This example demonstrates how easy it is to accidentally implement a DOM XSS vulnerability: The application was expecting an image URL, but also accepts all sorts of strings, which are then parsed into HTML and JavaScripts. This is enough to enable XSS attacks.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals

Since without the "-Pzo" flags we can't detect multiple lines[[1]](https://stackoverflow.com/questions/3717772/regex-grep-for-multi-line-search-needed), I think its better if we risk a few false-positives instead of missing a potential XSS vulnerability.

Ideally, we would use this regex: `` `(.|\n)*\$(.|\n)*` `` but this is what we have :P