### PR TITLE
Fix regexes and introduce a check to prevent this occuring again

### DIFF
--- a/signatures/dotnet.db
+++ b/signatures/dotnet.db
@@ -152,7 +152,7 @@ Server\.CreateObject
 #\.Provider
 \.Open([[:space:]]*\(|[[:space:]]+[\"\']).*
 #ADODB.recordset
-New[[:space:]]+*OleDbConnection
+New[[:space:]]+OleDbConnection
 ExecuteReader[[:space:]]*\(
 #DataSource
 SqlCo(mmand|nnection).*\=

--- a/signatures/dotnet/sql.db
+++ b/signatures/dotnet/sql.db
@@ -20,7 +20,7 @@ Server\.CreateObject
 #\.Provider
 \.Open([[:space:]]*\(|[[:space:]]+[\"\']).*
 #ADODB.recordset
-New[[:space:]]+*OleDbConnection
+New[[:space:]]+OleDbConnection
 ExecuteReader[[:space:]]*\(
 #DataSource
 SqlCo(mmand|nnection).*\=

--- a/signatures/perl.db
+++ b/signatures/perl.db
@@ -20,7 +20,7 @@ use[[:space:]]+.*\$.*->param[[:space:]]*\(.*\).*
 (ORDER BY|order by)[[:space:]]+.*\$.*->param[[:space:]]*\(.*\)
 (LIMIT|limit)[[:space:]]+.*\$.*->param[[:space:]]*\(.*\)
 # Perl superglobal signatures
-\$ARGV\[.*?\]
+\$ARGV\[[^\]]+\]
 \$ARGC
 \$ENV
 # Perl signatures

--- a/signatures/perl/superglobal.db
+++ b/signatures/perl/superglobal.db
@@ -1,4 +1,4 @@
 # Perl superglobal signatures
-\$ARGV\[.*?\]
+\$ARGV\[[^\]]+\]
 \$ARGC
 \$ENV

--- a/signatures/sql.db
+++ b/signatures/sql.db
@@ -22,7 +22,7 @@ Server\.CreateObject
 #\.Provider
 \.Open([[:space:]]*\(|[[:space:]]+[\"\']).*
 #ADODB.recordset
-New[[:space:]]+*OleDbConnection
+New[[:space:]]+OleDbConnection
 ExecuteReader[[:space:]]*\(
 #DataSource
 SqlCo(mmand|nnection).*\=

--- a/t/t-signaturebugs.sh
+++ b/t/t-signaturebugs.sh
@@ -5,4 +5,5 @@ test_description='Signature bug checks'
 
 # Tests
 test_expect_code 1 'Blank lines in signature files' 'grep -rE "^$" ../signatures'
+test_expect_code 1 'Bad quantifiers in signatures' 'grep -rE "[+*?][+*?]" ../signatures'
 test_done


### PR DESCRIPTION
Bad regexes caused breakage with bsdgrep and may have caused false negatives under other greps.

Fixes the root cause of pull request #59 