### PR TITLE
Add ability to only search files with specified extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ OPTIONS
   -d <dbname> database to use or /path/to/file.db (uses default if not specified)
   -A scan unwanted and difficult (ALL) files
   -x exclude these files (comma separated list: -x *.js,*.sql)
+  -n include only these files (comma separated list: -x *.js,*.sql)
   -i case in-sensitive scan
   -c <num> number of lines of context to display before and after a match, default is 1
 

--- a/graudit
+++ b/graudit
@@ -62,6 +62,7 @@ OPTIONS
   -d <dbname> database to use or /path/to/file.db (uses default if not specified)
   -A scan unwanted and difficult (ALL) files
   -x exclude these files (comma separated list: -x *.js,*.sql)
+  -n include only these files (comma separated list: -x *.js,*.sql)
   -i case in-sensitive scan
   -c <num> number of lines of context to display, default is 2
 
@@ -102,7 +103,7 @@ listdb () {
     fi
 }
 
-while getopts "AbBhvilLzZd:c:x:" opt; do
+while getopts "AbBhvilLzZd:c:x:n:" opt; do
     case $opt in
         B)
             hidebanner=1
@@ -144,6 +145,15 @@ while getopts "AbBhvilLzZd:c:x:" opt; do
             IFS=','
             for ign in $OPTARG; do
                 ignorepattern="$ignorepattern --exclude=$ign"
+            done
+            IFS=$OIFS
+        ;;
+
+        n)
+            OIFS=$IFS
+            IFS=','
+            for inc in $OPTARG; do
+                incpattern="$incpattern --include=$inc"
             done
             IFS=$OIFS
         ;;
@@ -207,7 +217,7 @@ $BINFILE --color=$color \
          --exclude-dir=.svn \
          --exclude-dir=CVS \
          --exclude-dir=.git \
-         $excludefiles \
+         $incpattern $excludefiles \
          $icase $ignorepattern \
          -n -R -H -C "$context" -E \
          -f "$database" $@ | \


### PR DESCRIPTION
**Description**
I made a minor change to allow only search files with the specified extension using the -n option. It is just a tweak of the existing exclusion option. The exclusion options should still work and if conflicting include and exclude options are given, the last match wins. I found this useful for searching code bases with too many false positives in other file types. 

